### PR TITLE
Disable scroll position restoration on mobile devices

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,1 +1,734 @@
-if(!self.define){let e,s={};const a=(a,t)=>(a=new URL(a+".js",t).href,s[a]||new Promise(s=>{if("document"in self){const e=document.createElement("script");e.src=a,e.onload=s,document.head.appendChild(e)}else e=a,importScripts(a),s()}).then(()=>{let e=s[a];if(!e)throw new Error(`Module ${a} didn’t register its module`);return e}));self.define=(t,i)=>{const r=e||("document"in self?document.currentScript.src:"")||location.href;if(s[r])return;let n={};const c=e=>a(e,r),u={module:{uri:r},exports:n,require:c};s[r]=Promise.all(t.map(e=>u[e]||c(e))).then(e=>(i(...e),n))}}define(["./workbox-14aa2a4a"],function(e){"use strict";importScripts(),self.skipWaiting(),e.clientsClaim(),e.precacheAndRoute([{url:"/API_DOCUMENTATION.md",revision:"28c12eef855fbf009ef39134e9d619f4"},{url:"/DATABASE_SCHEMA.md",revision:"4cbc910c204bbad96957649e962f9132"},{url:"/FAQ.md",revision:"b5c292a33f5bb5a4915d1c6fc8b84760"},{url:"/FEATURE_TUTORIALS.md",revision:"0236a0ccf5f0b34f27699d39174366f6"},{url:"/TROUBLESHOOTING.md",revision:"29b6a4bf170f0ad8776daf17fb54f224"},{url:"/USER_MANUAL.md",revision:"a6fe1dfcb0b96c8847ab3a6374f51809"},{url:"/_next/app-build-manifest.json",revision:"298e1817b5ab543d0eb33a31f728eab7"},{url:"/_next/static/chunks/1684-2e692b19a9fbc935.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/2108-ebc69cd97d47eb3b.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/2836-00bba3c6ffb1c76f.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/3182-d891821a86285cab.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/3188-9c40a88796579baa.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/3448-2f0f2435a2ee5a76.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/3814-925e3f38122860f4.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/4028-85ceb5296df53cf2.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/4bd1b696-6e00bd47f6f0a493.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/5003-de23cc22a4f47d51.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/5672-71f2a71d96eb6b30.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/5963-b24e3515455c8990.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/635-a1cf3ff93017f00a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/6874-db72251a98b08786.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/7031-de7fe912fd536763.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/711-1d7dd0781b45afd8.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/7259-3fe9e7affec094af.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/7718-13a326b76734fbdb.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/8037-7fcce052fb8c60e3.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/8259-018b1f26f311ead7.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/8527-5833ccd0f60f1753.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/9557-c6aff4243531b88e.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/9964-c617084e90eb4fc1.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/_not-found/page-7279cf51c5746c08.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/audit-logs/route-1248ace4ee5b5aea.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/backup/restore/route-16bcab715e77329a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/backup/route-cf405ba6ab059734.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/backup/verify/route-73a1a8470b570b49.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/clear-cache/route-45ffea9f3e920b51.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/data-integrity/route-4410b1844c94c990.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/database-performance/optimize/route-74aa1bb2ec013770.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/database-performance/route-9897e142a6287109.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/reset-data/route-172212dc8104051c.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/test-constraint/route-07132abf2e328355.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/admin/users/%5Bid%5D/reset-password/route-eae1b1280da2d67e.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/audit/route-ead404207bf77801.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/auth/%5B...nextauth%5D/route-e0b3889aff534604.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/auth/change-password/route-b41e8bd71795890d.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/auth/register/route-acce3448954aca93.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/backup/route-4d449a02184c7739.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/contribution-progress/route-d75a3d81b02cb866.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/contributions/%5Bid%5D/route-1411582e1a033560.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/contributions/route-360c5a7d14c2dbb1.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/cost-analysis/route-fdd39c880c3a04dc.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/dashboard/max-daily-consumption/route-fb0d116842132dc1.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/dashboard/progressive-consumption/route-e884cd882f37c2f3.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/dashboard/route-dd3a0e2a19175ed6.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/dashboard/running-balance/route-ad6e7597971fc019.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/db-status/route-d562475ca78d1998.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/debug-export/route-ff5c632eb3c74511.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/export-debug/route-a4f6cae0fa038538.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/export/route-c10e9e179a552cf9.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/health/route-1ab5c6f9fde7541f.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/import/route-e437282502f60297.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/meter-readings/%5Bid%5D/route-0d54693fb8a3aa97.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/meter-readings/latest/route-c45aea34e293abee.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/meter-readings/route-c035abbc75cf8547.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/purchases/%5Bid%5D/context/route-ca21fb0374e3a598.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/purchases/%5Bid%5D/impact-analysis/route-94aa4bdcd7b63674.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/purchases/%5Bid%5D/route-b8413f049c62f2cd.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/purchases/route-8e9478d691d0e070.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/reports/efficiency/route-d7fabdc39d3be285.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/reports/financial/route-5ea0725855c67182.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/reports/route-4c247a563dc0763b.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/reports/usage/route-2d1705f44927eb0f.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/seed-test-data/route-1579eb6e1b423266.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/test-data/route-b312ca6e5d727b79.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/test-export-simple/route-e14fef45c7c0a3e4.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/test-export/route-263d5d2e0ae22ebe.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/test-pdf-table/route-3f4577cd660b8f80.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/test-pdf/route-68bb5e4d5e43f46a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/user/theme/route-d8b7ced7142d1602.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/users/%5Bid%5D/route-8ea9f59919966644.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/users/route-e088ff7f65838636.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/validate-contribution-meter/route-838900bdd6211299.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/validate-meter-reading-historical/route-d94390fb5308f805.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/validate-meter-reading/route-a7caf4767b9eb953.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/api/validate-sequential-purchase/route-1f3acb38d8c2828b.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/auth/change-password/page-537d9b931d1508f2.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/auth/locked/page-a246779587926636.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/auth/signin/page-3339c82d24eb0afa.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/auth/signup/page-9e2e095736cec16e.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/audit-logs/page-ba9d23da96077a60.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/audit/page-163cd0aea3035f37.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/database-performance/page-45f3813e421f492c.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/monitoring/page-6bf95e5f1c0411dd.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/page-97d5023a4df5e269.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/reports/page-876da27b53868552.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/security/page-5e3bbc08dacfb127.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/settings/page-b182043d47e97f08.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/users/%5Bid%5D/edit/page-5d8084886a54cdcd.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/users/new/page-9a1390418ceaeda1.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/admin/users/page-d05d697570f322d9.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/contributions/edit/%5Bid%5D/page-6826d2d3b2aa3030.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/contributions/new/page-54ed0dd1f70a2824.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/contributions/page-2924ecb7c2cb2fca.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/cost-analysis/page-3e67b9cfff87e6ad.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/data-management/page-aadbbfa8f7af05aa.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/meter-readings/page-b55405895060faec.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/page-cddc7fb8a7f53e89.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/personal/page-1187127f9ad95fff.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/profile/page-9be7e1a3a92282ac.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/purchases/edit/%5Bid%5D/page-b1d840ccf71cf08a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/purchases/history/page-ed18b7bfbe1a45b6.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/purchases/new/page-48c9e64daa7073a8.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/purchases/page-7bdc51e8230c6011.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/reports/efficiency/page-060e4a17c7ddfe49.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/reports/financial/page-4249b964033dbf0a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/dashboard/reports/usage/page-11163053a59160ac.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/error-ed9edcbd5729441a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/help/page-a9723f70576043d8.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/layout-4f14d92981b67e72.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/not-found-00724538c502ec72.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/page-e04226eb4d62744b.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/test-charts/page-ca9671960312ae4a.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/app/test-seed/page-0b0de84348107540.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/ca377847-b5e894c7666aac65.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/framework-82b67a6346ddd02b.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/main-app-3b47fd94dd6fc886.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/main-eae3a3bb9e4c25db.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/pages/_app-5d1abe03d322390c.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/pages/_error-3b2a1d523de49635.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/chunks/polyfills-42372ed130431b0a.js",revision:"846118c33b2c0e922d7b3a7676f81f6f"},{url:"/_next/static/chunks/webpack-93947014924b4f5d.js",revision:"fJI06xq9rgxUtDOgJ3-_M"},{url:"/_next/static/css/d68883daaba88b40.css",revision:"d68883daaba88b40"},{url:"/_next/static/fJI06xq9rgxUtDOgJ3-_M/_buildManifest.js",revision:"cf27e85d739dc41bce78016302b736a5"},{url:"/_next/static/fJI06xq9rgxUtDOgJ3-_M/_ssgManifest.js",revision:"b6652df95db52feb4daf4eca35380933"},{url:"/_next/static/media/569ce4b8f30dc480-s.p.woff2",revision:"ef6cefb32024deac234e82f932a95cbd"},{url:"/_next/static/media/747892c23ea88013-s.woff2",revision:"a0761690ccf4441ace5cec893b82d4ab"},{url:"/_next/static/media/8d697b304b401681-s.woff2",revision:"cc728f6c0adb04da0dfcb0fc436a8ae5"},{url:"/_next/static/media/93f479601ee12b01-s.p.woff2",revision:"da83d5f06d825c5ae65b7cca706cb312"},{url:"/_next/static/media/9610d9e46709d722-s.woff2",revision:"7b7c0ef93df188a852344fc272fc096b"},{url:"/_next/static/media/ba015fad6dcf6784-s.woff2",revision:"8ea4f719af3312a055caf09f34c89a77"},{url:"/favicon.ico.svg",revision:"76cd72d922f63a429f6ab2efc2d72cc3"},{url:"/favicon.svg",revision:"76cd72d922f63a429f6ab2efc2d72cc3"},{url:"/file.svg",revision:"d09f95206c3fa0bb9bd9fefabfd0ea71"},{url:"/globe.svg",revision:"2aaafa6a49b6563925fe440891e32717"},{url:"/icons/create-simple-icons.js",revision:"624ab6ae1600eff9fefc5db748a3fe13"},{url:"/icons/generate-icons.js",revision:"4c75005f61c25fa92130dd305f767e5f"},{url:"/icons/icon-128x128.svg",revision:"261ddab8e95eb7f085a4c831ce82445c"},{url:"/icons/icon-144x144.svg",revision:"9f3eabe0628f5f9adcbd2ec4955a339f"},{url:"/icons/icon-152x152.svg",revision:"d3bcb0ca20178b7f8d5dd12435068144"},{url:"/icons/icon-192x192.svg",revision:"52b96782939b266b2779709a4e0cfe3f"},{url:"/icons/icon-32x32.svg",revision:"916a9b62bbb7de65af965e3a5a9a9752"},{url:"/icons/icon-384x384.svg",revision:"8a0b0a056eeed6b54a98af6df124b93e"},{url:"/icons/icon-512x512.svg",revision:"e6097f7d58fdb0a55f55215eb3d0d9e7"},{url:"/icons/icon-72x72.svg",revision:"300126fdde24b4f4375ae42dccdb4bf9"},{url:"/icons/icon-96x96.svg",revision:"ee90403cd7a8aea71f16674734acb3ad"},{url:"/icons/icon-base.svg",revision:"ca7b35eab0584e8408469fe1c7078182"},{url:"/icons/shortcut-contribution.svg",revision:"aa444c2a1f5a82ce8cbd9c5724cbaabd"},{url:"/icons/shortcut-purchase.svg",revision:"96314fa61f82b7e8ee24a88746052b7c"},{url:"/icons/shortcut-reports.svg",revision:"a1e5e3177d17d08c5d44566b6d0a92f7"},{url:"/manifest.json",revision:"03c9efe6064635cb26970d833333bab8"},{url:"/next.svg",revision:"8e061864f388b47f33a1c3780831193e"},{url:"/vercel.svg",revision:"c0af2f507b369b085b35ef4bbe3bcf1e"},{url:"/window.svg",revision:"a2760511c65806022ad20adf74370ff3"}],{ignoreURLParametersMatching:[]}),e.cleanupOutdatedCaches(),e.registerRoute("/",new e.NetworkFirst({cacheName:"start-url",plugins:[{cacheWillUpdate:async({request:e,response:s,event:a,state:t})=>s&&"opaqueredirect"===s.type?new Response(s.body,{status:200,statusText:"OK",headers:s.headers}):s}]}),"GET"),e.registerRoute(/^https:\/\/fonts\.googleapis\.com\/.*/i,new e.CacheFirst({cacheName:"google-fonts",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:31536e3})]}),"GET"),e.registerRoute(/^https:\/\/fonts\.gstatic\.com\/.*/i,new e.CacheFirst({cacheName:"google-fonts-static",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:31536e3})]}),"GET"),e.registerRoute(/\.(?:js|css|woff|woff2|ttf|eot)$/i,new e.StaleWhileRevalidate({cacheName:"static-assets",plugins:[new e.ExpirationPlugin({maxEntries:64,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\/api\/.*$/i,new e.NetworkFirst({cacheName:"api-cache",networkTimeoutSeconds:10,plugins:[new e.ExpirationPlugin({maxEntries:16,maxAgeSeconds:86400})]}),"GET")});
+if (!self.define) {
+  let e,
+    s = {};
+  const a = (a, i) => (
+    (a = new URL(a + '.js', i).href),
+    s[a] ||
+      new Promise((s) => {
+        if ('document' in self) {
+          const e = document.createElement('script');
+          ((e.src = a), (e.onload = s), document.head.appendChild(e));
+        } else ((e = a), importScripts(a), s());
+      }).then(() => {
+        let e = s[a];
+        if (!e) throw new Error(`Module ${a} didn’t register its module`);
+        return e;
+      })
+  );
+  self.define = (i, t) => {
+    const n =
+      e ||
+      ('document' in self ? document.currentScript.src : '') ||
+      location.href;
+    if (s[n]) return;
+    let c = {};
+    const r = (e) => a(e, n),
+      u = { module: { uri: n }, exports: c, require: r };
+    s[n] = Promise.all(i.map((e) => u[e] || r(e))).then((e) => (t(...e), c));
+  };
+}
+define(['./workbox-14aa2a4a'], function (e) {
+  'use strict';
+  (importScripts(),
+    self.skipWaiting(),
+    e.clientsClaim(),
+    e.precacheAndRoute(
+      [
+        {
+          url: '/API_DOCUMENTATION.md',
+          revision: '28c12eef855fbf009ef39134e9d619f4',
+        },
+        {
+          url: '/DATABASE_SCHEMA.md',
+          revision: '4cbc910c204bbad96957649e962f9132',
+        },
+        { url: '/FAQ.md', revision: 'b5c292a33f5bb5a4915d1c6fc8b84760' },
+        {
+          url: '/FEATURE_TUTORIALS.md',
+          revision: '0236a0ccf5f0b34f27699d39174366f6',
+        },
+        {
+          url: '/TROUBLESHOOTING.md',
+          revision: '29b6a4bf170f0ad8776daf17fb54f224',
+        },
+        {
+          url: '/USER_MANUAL.md',
+          revision: 'a6fe1dfcb0b96c8847ab3a6374f51809',
+        },
+        {
+          url: '/_next/app-build-manifest.json',
+          revision: '6ad0bcf60f0115fc9fef1d3c1f8748f5',
+        },
+        {
+          url: '/_next/static/ReSTbXDmFSKg0RVA22fJR/_buildManifest.js',
+          revision: 'cf27e85d739dc41bce78016302b736a5',
+        },
+        {
+          url: '/_next/static/ReSTbXDmFSKg0RVA22fJR/_ssgManifest.js',
+          revision: 'b6652df95db52feb4daf4eca35380933',
+        },
+        {
+          url: '/_next/static/chunks/1684-2e692b19a9fbc935.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/2108-ebc69cd97d47eb3b.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/2836-00bba3c6ffb1c76f.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/3182-d891821a86285cab.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/3188-9c40a88796579baa.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/3448-2f0f2435a2ee5a76.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/3814-925e3f38122860f4.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/4028-85ceb5296df53cf2.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/4bd1b696-6e00bd47f6f0a493.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/5003-de23cc22a4f47d51.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/5672-71f2a71d96eb6b30.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/5963-b24e3515455c8990.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/635-a1cf3ff93017f00a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/6874-db72251a98b08786.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/7031-de7fe912fd536763.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/711-1d7dd0781b45afd8.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/7259-3fe9e7affec094af.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/7718-13a326b76734fbdb.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/8037-7fcce052fb8c60e3.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/8259-018b1f26f311ead7.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/8527-5833ccd0f60f1753.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/9557-c6aff4243531b88e.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/9964-c617084e90eb4fc1.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/_not-found/page-7279cf51c5746c08.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/audit-logs/route-1248ace4ee5b5aea.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/backup/restore/route-16bcab715e77329a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/backup/route-cf405ba6ab059734.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/backup/verify/route-73a1a8470b570b49.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/clear-cache/route-45ffea9f3e920b51.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/data-integrity/route-4410b1844c94c990.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/database-performance/optimize/route-74aa1bb2ec013770.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/database-performance/route-9897e142a6287109.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/reset-data/route-172212dc8104051c.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/test-constraint/route-07132abf2e328355.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/admin/users/%5Bid%5D/reset-password/route-eae1b1280da2d67e.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/audit/route-ead404207bf77801.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/auth/%5B...nextauth%5D/route-e0b3889aff534604.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/auth/change-password/route-b41e8bd71795890d.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/auth/register/route-acce3448954aca93.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/backup/route-4d449a02184c7739.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/contribution-progress/route-d75a3d81b02cb866.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/contributions/%5Bid%5D/route-1411582e1a033560.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/contributions/route-360c5a7d14c2dbb1.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/cost-analysis/route-fdd39c880c3a04dc.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/dashboard/max-daily-consumption/route-fb0d116842132dc1.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/dashboard/progressive-consumption/route-e884cd882f37c2f3.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/dashboard/route-dd3a0e2a19175ed6.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/dashboard/running-balance/route-ad6e7597971fc019.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/db-status/route-d562475ca78d1998.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/debug-export/route-ff5c632eb3c74511.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/export-debug/route-a4f6cae0fa038538.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/export/route-c10e9e179a552cf9.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/health/route-1ab5c6f9fde7541f.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/import/route-e437282502f60297.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/meter-readings/%5Bid%5D/route-0d54693fb8a3aa97.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/meter-readings/latest/route-c45aea34e293abee.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/meter-readings/route-c035abbc75cf8547.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/purchases/%5Bid%5D/context/route-ca21fb0374e3a598.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/purchases/%5Bid%5D/impact-analysis/route-94aa4bdcd7b63674.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/purchases/%5Bid%5D/route-b8413f049c62f2cd.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/purchases/route-8e9478d691d0e070.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/reports/efficiency/route-d7fabdc39d3be285.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/reports/financial/route-5ea0725855c67182.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/reports/route-4c247a563dc0763b.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/reports/usage/route-2d1705f44927eb0f.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/seed-test-data/route-1579eb6e1b423266.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/test-data/route-b312ca6e5d727b79.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/test-export-simple/route-e14fef45c7c0a3e4.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/test-export/route-263d5d2e0ae22ebe.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/test-pdf-table/route-3f4577cd660b8f80.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/test-pdf/route-68bb5e4d5e43f46a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/user/theme/route-d8b7ced7142d1602.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/users/%5Bid%5D/route-8ea9f59919966644.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/users/route-e088ff7f65838636.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/validate-contribution-meter/route-838900bdd6211299.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/validate-meter-reading-historical/route-d94390fb5308f805.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/validate-meter-reading/route-a7caf4767b9eb953.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/api/validate-sequential-purchase/route-1f3acb38d8c2828b.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/auth/change-password/page-537d9b931d1508f2.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/auth/locked/page-a246779587926636.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/auth/signin/page-3339c82d24eb0afa.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/auth/signup/page-9e2e095736cec16e.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/audit-logs/page-ba9d23da96077a60.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/audit/page-163cd0aea3035f37.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/database-performance/page-45f3813e421f492c.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/monitoring/page-6bf95e5f1c0411dd.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/page-97d5023a4df5e269.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/reports/page-876da27b53868552.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/security/page-5e3bbc08dacfb127.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/settings/page-b182043d47e97f08.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/users/%5Bid%5D/edit/page-5d8084886a54cdcd.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/users/new/page-9a1390418ceaeda1.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/admin/users/page-d05d697570f322d9.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/contributions/edit/%5Bid%5D/page-6826d2d3b2aa3030.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/contributions/new/page-54ed0dd1f70a2824.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/contributions/page-2e15fb0c7c875c10.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/cost-analysis/page-3e67b9cfff87e6ad.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/data-management/page-aadbbfa8f7af05aa.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/meter-readings/page-b55405895060faec.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/page-0b502e78805614db.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/personal/page-1187127f9ad95fff.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/profile/page-9be7e1a3a92282ac.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/purchases/edit/%5Bid%5D/page-b1d840ccf71cf08a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/purchases/history/page-ed18b7bfbe1a45b6.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/purchases/new/page-48c9e64daa7073a8.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/purchases/page-7bdc51e8230c6011.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/reports/efficiency/page-060e4a17c7ddfe49.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/reports/financial/page-4249b964033dbf0a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/dashboard/reports/usage/page-11163053a59160ac.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/error-ed9edcbd5729441a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/help/page-a9723f70576043d8.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/layout-4f14d92981b67e72.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/not-found-00724538c502ec72.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/page-e04226eb4d62744b.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/test-charts/page-ca9671960312ae4a.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/app/test-seed/page-0b0de84348107540.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/ca377847-b5e894c7666aac65.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/framework-82b67a6346ddd02b.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/main-app-3b47fd94dd6fc886.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/main-eae3a3bb9e4c25db.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/pages/_app-5d1abe03d322390c.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/pages/_error-3b2a1d523de49635.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/chunks/polyfills-42372ed130431b0a.js',
+          revision: '846118c33b2c0e922d7b3a7676f81f6f',
+        },
+        {
+          url: '/_next/static/chunks/webpack-93947014924b4f5d.js',
+          revision: 'ReSTbXDmFSKg0RVA22fJR',
+        },
+        {
+          url: '/_next/static/css/d68883daaba88b40.css',
+          revision: 'd68883daaba88b40',
+        },
+        {
+          url: '/_next/static/media/569ce4b8f30dc480-s.p.woff2',
+          revision: 'ef6cefb32024deac234e82f932a95cbd',
+        },
+        {
+          url: '/_next/static/media/747892c23ea88013-s.woff2',
+          revision: 'a0761690ccf4441ace5cec893b82d4ab',
+        },
+        {
+          url: '/_next/static/media/8d697b304b401681-s.woff2',
+          revision: 'cc728f6c0adb04da0dfcb0fc436a8ae5',
+        },
+        {
+          url: '/_next/static/media/93f479601ee12b01-s.p.woff2',
+          revision: 'da83d5f06d825c5ae65b7cca706cb312',
+        },
+        {
+          url: '/_next/static/media/9610d9e46709d722-s.woff2',
+          revision: '7b7c0ef93df188a852344fc272fc096b',
+        },
+        {
+          url: '/_next/static/media/ba015fad6dcf6784-s.woff2',
+          revision: '8ea4f719af3312a055caf09f34c89a77',
+        },
+        {
+          url: '/favicon.ico.svg',
+          revision: '76cd72d922f63a429f6ab2efc2d72cc3',
+        },
+        { url: '/favicon.svg', revision: '76cd72d922f63a429f6ab2efc2d72cc3' },
+        { url: '/file.svg', revision: 'd09f95206c3fa0bb9bd9fefabfd0ea71' },
+        { url: '/globe.svg', revision: '2aaafa6a49b6563925fe440891e32717' },
+        {
+          url: '/icons/create-simple-icons.js',
+          revision: '624ab6ae1600eff9fefc5db748a3fe13',
+        },
+        {
+          url: '/icons/generate-icons.js',
+          revision: '4c75005f61c25fa92130dd305f767e5f',
+        },
+        {
+          url: '/icons/icon-128x128.svg',
+          revision: '261ddab8e95eb7f085a4c831ce82445c',
+        },
+        {
+          url: '/icons/icon-144x144.svg',
+          revision: '9f3eabe0628f5f9adcbd2ec4955a339f',
+        },
+        {
+          url: '/icons/icon-152x152.svg',
+          revision: 'd3bcb0ca20178b7f8d5dd12435068144',
+        },
+        {
+          url: '/icons/icon-192x192.svg',
+          revision: '52b96782939b266b2779709a4e0cfe3f',
+        },
+        {
+          url: '/icons/icon-32x32.svg',
+          revision: '916a9b62bbb7de65af965e3a5a9a9752',
+        },
+        {
+          url: '/icons/icon-384x384.svg',
+          revision: '8a0b0a056eeed6b54a98af6df124b93e',
+        },
+        {
+          url: '/icons/icon-512x512.svg',
+          revision: 'e6097f7d58fdb0a55f55215eb3d0d9e7',
+        },
+        {
+          url: '/icons/icon-72x72.svg',
+          revision: '300126fdde24b4f4375ae42dccdb4bf9',
+        },
+        {
+          url: '/icons/icon-96x96.svg',
+          revision: 'ee90403cd7a8aea71f16674734acb3ad',
+        },
+        {
+          url: '/icons/icon-base.svg',
+          revision: 'ca7b35eab0584e8408469fe1c7078182',
+        },
+        {
+          url: '/icons/shortcut-contribution.svg',
+          revision: 'aa444c2a1f5a82ce8cbd9c5724cbaabd',
+        },
+        {
+          url: '/icons/shortcut-purchase.svg',
+          revision: '96314fa61f82b7e8ee24a88746052b7c',
+        },
+        {
+          url: '/icons/shortcut-reports.svg',
+          revision: 'a1e5e3177d17d08c5d44566b6d0a92f7',
+        },
+        { url: '/manifest.json', revision: '03c9efe6064635cb26970d833333bab8' },
+        { url: '/next.svg', revision: '8e061864f388b47f33a1c3780831193e' },
+        { url: '/vercel.svg', revision: 'c0af2f507b369b085b35ef4bbe3bcf1e' },
+        { url: '/window.svg', revision: 'a2760511c65806022ad20adf74370ff3' },
+      ],
+      { ignoreURLParametersMatching: [] }
+    ),
+    e.cleanupOutdatedCaches(),
+    e.registerRoute(
+      '/',
+      new e.NetworkFirst({
+        cacheName: 'start-url',
+        plugins: [
+          {
+            cacheWillUpdate: async ({
+              request: e,
+              response: s,
+              event: a,
+              state: i,
+            }) =>
+              s && 'opaqueredirect' === s.type
+                ? new Response(s.body, {
+                    status: 200,
+                    statusText: 'OK',
+                    headers: s.headers,
+                  })
+                : s,
+          },
+        ],
+      }),
+      'GET'
+    ),
+    e.registerRoute(
+      /^https:\/\/fonts\.googleapis\.com\/.*/i,
+      new e.CacheFirst({
+        cacheName: 'google-fonts',
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 4, maxAgeSeconds: 31536e3 }),
+        ],
+      }),
+      'GET'
+    ),
+    e.registerRoute(
+      /^https:\/\/fonts\.gstatic\.com\/.*/i,
+      new e.CacheFirst({
+        cacheName: 'google-fonts-static',
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 4, maxAgeSeconds: 31536e3 }),
+        ],
+      }),
+      'GET'
+    ),
+    e.registerRoute(
+      /\.(?:js|css|woff|woff2|ttf|eot)$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: 'static-assets',
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 64, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      'GET'
+    ),
+    e.registerRoute(
+      /\/api\/.*$/i,
+      new e.NetworkFirst({
+        cacheName: 'api-cache',
+        networkTimeoutSeconds: 10,
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 16, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      'GET'
+    ));
+});

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -12,70 +12,85 @@ interface ScrollPosition {
 export function useScrollRestoration(key: string = 'dashboard') {
   const router = useRouter();
   const pathname = usePathname();
-  const savedScrollPosition = useRef<ScrollPosition | null>(null);
   const isRestoringScroll = useRef(false);
 
   // Storage key for this specific page
   const storageKey = `scroll-position-${key}`;
 
+  // Check if the device is mobile
+  const isMobile = useCallback(() => {
+    if (typeof window === 'undefined') return false;
+    return (
+      window.innerWidth <= 768 ||
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent
+      )
+    );
+  }, []);
+
   // Save current scroll position to sessionStorage
   const saveScrollPosition = useCallback(() => {
     if (typeof window === 'undefined') return;
-    
+
+    // Don't save scroll position on mobile devices
+    if (isMobile()) return;
+
     const scrollPosition: ScrollPosition = {
       x: window.scrollX,
       y: window.scrollY,
-      timestamp: Date.now()
+      timestamp: Date.now(),
     };
-    
+
     try {
       sessionStorage.setItem(storageKey, JSON.stringify(scrollPosition));
     } catch (error) {
       console.warn('Failed to save scroll position:', error);
     }
-  }, [storageKey]);
+  }, [storageKey, isMobile]);
 
   // Restore scroll position from sessionStorage
   const restoreScrollPosition = useCallback(() => {
     if (typeof window === 'undefined') return;
-    
+
+    // Don't restore scroll position on mobile devices
+    if (isMobile()) return;
+
     try {
       const saved = sessionStorage.getItem(storageKey);
       if (!saved) return;
-      
+
       const scrollPosition: ScrollPosition = JSON.parse(saved);
-      
+
       // Only restore if the saved position is recent (within last 5 minutes)
       const isRecent = Date.now() - scrollPosition.timestamp < 5 * 60 * 1000;
       if (!isRecent) {
         sessionStorage.removeItem(storageKey);
         return;
       }
-      
+
       // Set flag to prevent interference with other scroll events
       isRestoringScroll.current = true;
-      
+
       // Restore scroll position
       window.scrollTo({
         left: scrollPosition.x,
         top: scrollPosition.y,
-        behavior: 'instant'
+        behavior: 'instant',
       });
-      
+
       // Reset flag after a short delay
       setTimeout(() => {
         isRestoringScroll.current = false;
       }, 100);
-      
     } catch (error) {
       console.warn('Failed to restore scroll position:', error);
     }
-  }, [storageKey]);
+  }, [storageKey, isMobile]);
 
   // Clear saved scroll position
   const clearScrollPosition = useCallback(() => {
     if (typeof window === 'undefined') return;
-    
+
     try {
       sessionStorage.removeItem(storageKey);
     } catch (error) {
@@ -84,27 +99,39 @@ export function useScrollRestoration(key: string = 'dashboard') {
   }, [storageKey]);
 
   // Navigate to another page and save current scroll position
-  const navigateAndSaveScroll = useCallback((path: string) => {
-    saveScrollPosition();
-    router.push(path);
-  }, [router, saveScrollPosition]);
+  const navigateAndSaveScroll = useCallback(
+    (path: string) => {
+      // Only save scroll position on non-mobile devices
+      if (!isMobile()) {
+        saveScrollPosition();
+      }
+      router.push(path);
+    },
+    [router, saveScrollPosition, isMobile]
+  );
 
   // Navigate back and restore scroll position
-  const navigateBackAndRestore = useCallback((path: string) => {
-    // Don't save scroll position when navigating back
-    router.push(path);
-    // Scroll restoration will happen in useEffect after navigation
-  }, [router]);
+  const navigateBackAndRestore = useCallback(
+    (path: string) => {
+      // Don't save scroll position when navigating back
+      router.push(path);
+      // Scroll restoration will happen in useEffect after navigation
+    },
+    [router]
+  );
 
   // Effect to handle scroll restoration on page load/navigation
   useEffect(() => {
     // Only restore scroll position if we're on the target page
-    if (pathname === `/${key}` || (key === 'dashboard' && pathname === '/dashboard')) {
+    if (
+      pathname === `/${key}` ||
+      (key === 'dashboard' && pathname === '/dashboard')
+    ) {
       // Small delay to ensure DOM is fully rendered
       const timeoutId = setTimeout(() => {
         restoreScrollPosition();
       }, 50);
-      
+
       return () => clearTimeout(timeoutId);
     }
   }, [pathname, key, restoreScrollPosition]);
@@ -129,12 +156,15 @@ export function useScrollRestoration(key: string = 'dashboard') {
     if (typeof window === 'undefined') return;
 
     const handleBeforeUnload = () => {
-      saveScrollPosition();
+      // Only save scroll position on non-mobile devices
+      if (!isMobile()) {
+        saveScrollPosition();
+      }
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [saveScrollPosition]);
+  }, [saveScrollPosition, isMobile]);
 
   return {
     saveScrollPosition,
@@ -142,6 +172,6 @@ export function useScrollRestoration(key: string = 'dashboard') {
     clearScrollPosition,
     navigateAndSaveScroll,
     navigateBackAndRestore,
-    isRestoringScroll: isRestoringScroll.current
+    isRestoringScroll: isRestoringScroll.current,
   };
 }


### PR DESCRIPTION
- Add mobile device detection using screen width (≤768px) and user agent strings
- Prevent scroll position saving on mobile devices in saveScrollPosition function
- Prevent scroll position restoration on mobile devices in restoreScrollPosition function
- Update navigateAndSaveScroll to skip saving scroll position on mobile devices
- Update beforeunload event handler to skip saving scroll position on mobile devices
- Remove unused savedScrollPosition ref to fix ESLint error
- Improves mobile performance by avoiding unnecessary scroll position operations
- Maintains full desktop functionality while optimizing mobile user experience

🤖 Generated with [Claude Code](https://claude.ai/code)