### PR TITLE
Fix sc create command formatting and add DisplayName parameter

### DIFF
--- a/scripts/windows-service/debug-install.js
+++ b/scripts/windows-service/debug-install.js
@@ -80,8 +80,8 @@ async function debugInstall() {
   console.log(`- Description: "${serviceDesc}"`);
   console.log('');
 
-  const psCommand = `sc.exe create "${serviceName}" binPath= "${nodeExe} ${scriptPath}" start= auto`;
-  const cmdCommand = `sc create "${serviceName}" binPath= "${nodeExe} ${scriptPath}" start= auto`;
+  const psCommand = `sc.exe create "${serviceName}" binPath= "\\"${nodeExe}\\" \\"${scriptPath}\\"" DisplayName= "${serviceName}" start= auto`;
+  const cmdCommand = `sc create "${serviceName}" binPath= "\\"${nodeExe}\\" \\"${scriptPath}\\"" DisplayName= "${serviceName}" start= auto`;
 
   console.log('Commands to create service:');
   console.log('');

--- a/scripts/windows-service/install-manual.js
+++ b/scripts/windows-service/install-manual.js
@@ -38,13 +38,13 @@ class ManualServiceInstaller {
     console.log('1️⃣  Create the service (PowerShell - use sc.exe):');
     console.log('```');
     console.log(
-      `sc.exe create "${this.serviceName}" binPath= "${this.nodeExe} ${this.scriptPath}" start= auto`
+      `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`
     );
     console.log('```');
     console.log('💡 Or in Command Prompt (cmd):');
     console.log('```');
     console.log(
-      `sc create "${this.serviceName}" binPath= "${this.nodeExe} ${this.scriptPath}" start= auto`
+      `sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`
     );
     console.log('```\n');
 
@@ -89,13 +89,13 @@ class ManualServiceInstaller {
 
     console.log('\n💡 Alternative single command (PowerShell):');
     console.log('```');
-    const singleCommand = `sc.exe create "${this.serviceName}" binPath= "${this.nodeExe} ${this.scriptPath}" start= auto; sc.exe description "${this.serviceName}" "${this.serviceDescription}"; sc.exe start "${this.serviceName}"`;
+    const singleCommand = `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto; sc.exe description "${this.serviceName}" "${this.serviceDescription}"; sc.exe start "${this.serviceName}"`;
     console.log(singleCommand);
     console.log('```\n');
 
     console.log('💡 For Command Prompt (cmd):');
     console.log('```');
-    const cmdCommand = `sc create "${this.serviceName}" binPath= "${this.nodeExe} ${this.scriptPath}" start= auto && sc description "${this.serviceName}" "${this.serviceDescription}" && sc start "${this.serviceName}"`;
+    const cmdCommand = `sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto && sc description "${this.serviceName}" "${this.serviceDescription}" && sc start "${this.serviceName}"`;
     console.log(cmdCommand);
     console.log('```\n');
 

--- a/scripts/windows-service/install-service-simple.js
+++ b/scripts/windows-service/install-service-simple.js
@@ -76,12 +76,13 @@ class SimpleServiceInstaller {
 
     try {
       // Create the service using sc create with proper escaping
-      const binPath = `${this.nodeExe} ${this.scriptPath}`;
-
-      console.log(`🔧 Creating service with binary path: ${binPath}`);
+      console.log(`🔧 Creating service...`);
+      console.log(`   Node.js: ${this.nodeExe}`);
+      console.log(`   Script: ${this.scriptPath}`);
 
       // Use sc.exe to avoid PowerShell alias conflicts
-      const createCommand = `sc.exe create ${this.serviceName} binPath= "${binPath}" DisplayName= "${this.serviceName}" Description= "${this.serviceDescription}" start= auto`;
+      // Format: sc.exe create "ServiceName" binPath= "\"node.exe\" \"script.js\"" DisplayName= "Display Name" start= auto
+      const createCommand = `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`;
 
       console.log(`🔧 Running: ${createCommand}`);
 
@@ -92,7 +93,7 @@ class SimpleServiceInstaller {
 
       // Try alternative method with different quoting
       try {
-        const altCommand = `sc.exe create ${this.serviceName} binPath= "${this.nodeExe} ${this.scriptPath}" start= auto`;
+        const altCommand = `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`;
         console.log(`🔧 Trying alternative: ${altCommand}`);
         execSync(altCommand, { stdio: 'inherit' });
         console.log('✅ Service created successfully with alternative method!');
@@ -101,8 +102,11 @@ class SimpleServiceInstaller {
 Primary error: ${err.message}
 Alternative error: ${altErr.message}
 
-Manual command to try:
-sc create "${this.serviceName}" binPath= "${this.nodeExe} ${this.scriptPath}" start= auto`);
+Manual command to try (PowerShell):
+sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto
+
+Manual command to try (Command Prompt):
+sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`);
       }
     }
   }


### PR DESCRIPTION
- Fixed binPath parameter to properly quote individual paths: "\"path1\" \"path2\""
- Added DisplayName parameter to all sc create commands
- Updated all service installation scripts with correct Windows service format
- Fixed manual installer, debug utility, and simple installer command formatting
- Enhanced error messages with properly formatted manual commands

🤖 Generated with [Claude Code](https://claude.ai/code)