### PR TITLE
Add server parameter to all sc.exe commands for proper Windows servic…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "service:debug": "node scripts/windows-service/debug-install.js",
     "service:uninstall": "node scripts/windows-service/uninstall-service.js",
     "service:status": "node scripts/windows-service/service-status.js",
-    "service:start": "sc.exe start \"ElectricityTokensTracker\"",
-    "service:stop": "sc.exe stop \"ElectricityTokensTracker\""
+    "service:start": "sc.exe . start \"ElectricityTokensTracker\"",
+    "service:stop": "sc.exe . stop \"ElectricityTokensTracker\""
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",

--- a/scripts/windows-service/debug-install.js
+++ b/scripts/windows-service/debug-install.js
@@ -45,11 +45,13 @@ async function debugInstall() {
   // Check existing service
   console.log('🔍 Checking Existing Service:');
   try {
-    const result = execSync(`sc query "${config.name}"`, { encoding: 'utf8' });
+    const result = execSync(`sc.exe . query "${config.name}"`, {
+      encoding: 'utf8',
+    });
     console.log('⚠️  Service already exists:');
     console.log(result);
     console.log(
-      '   You may need to delete it first with: sc delete "ElectricityTokensTracker"'
+      '   You may need to delete it first with: sc.exe . delete "ElectricityTokensTracker"'
     );
   } catch (err) {
     console.log('✅ No existing service found');
@@ -80,8 +82,8 @@ async function debugInstall() {
   console.log(`- Description: "${serviceDesc}"`);
   console.log('');
 
-  const psCommand = `sc.exe create "${serviceName}" binPath= "\\"${nodeExe}\\" \\"${scriptPath}\\"" DisplayName= "${serviceName}" start= auto`;
-  const cmdCommand = `sc create "${serviceName}" binPath= "\\"${nodeExe}\\" \\"${scriptPath}\\"" DisplayName= "${serviceName}" start= auto`;
+  const psCommand = `sc.exe . create "${serviceName}" binPath= "\\"${nodeExe}\\" \\"${scriptPath}\\"" DisplayName= "${serviceName}" start= auto`;
+  const cmdCommand = `sc.exe . create "${serviceName}" binPath= "\\"${nodeExe}\\" \\"${scriptPath}\\"" DisplayName= "${serviceName}" start= auto`;
 
   console.log('Commands to create service:');
   console.log('');
@@ -107,9 +109,11 @@ async function debugInstall() {
   console.log('2. Open PowerShell as Administrator');
   console.log('3. Paste and run the command');
   console.log(
-    '4. If successful, start with: sc start "ElectricityTokensTracker"'
+    '4. If successful, start with: sc.exe . start "ElectricityTokensTracker"'
   );
-  console.log('5. Check status with: sc query "ElectricityTokensTracker"');
+  console.log(
+    '5. Check status with: sc.exe . query "ElectricityTokensTracker"'
+  );
   console.log('');
 
   console.log('📞 For more help, run: npm run service:install-manual');

--- a/scripts/windows-service/install-manual.js
+++ b/scripts/windows-service/install-manual.js
@@ -38,44 +38,44 @@ class ManualServiceInstaller {
     console.log('1️⃣  Create the service (PowerShell - use sc.exe):');
     console.log('```');
     console.log(
-      `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`
+      `sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`
     );
     console.log('```');
     console.log('💡 Or in Command Prompt (cmd):');
     console.log('```');
     console.log(
-      `sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`
+      `sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`
     );
     console.log('```\n');
 
     console.log('2️⃣  Set service description:');
     console.log('```');
     console.log(
-      `sc.exe description "${this.serviceName}" "${this.serviceDescription}"`
+      `sc.exe . description "${this.serviceName}" "${this.serviceDescription}"`
     );
     console.log('```\n');
 
     console.log('3️⃣  Configure service recovery (optional):');
     console.log('```');
     console.log(
-      `sc.exe failure "${this.serviceName}" reset=3600 actions=restart/60000/restart/120000/restart/300000`
+      `sc.exe . failure "${this.serviceName}" reset=3600 actions=restart/60000/restart/120000/restart/300000`
     );
     console.log('```\n');
 
     console.log('4️⃣  Start the service:');
     console.log('```');
-    console.log(`sc.exe start "${this.serviceName}"`);
+    console.log(`sc.exe . start "${this.serviceName}"`);
     console.log('```\n');
 
     console.log('5️⃣  Check service status:');
     console.log('```');
-    console.log(`sc.exe query "${this.serviceName}"`);
+    console.log(`sc.exe . query "${this.serviceName}"`);
     console.log('```\n');
 
     console.log('🗑️  To remove the service later:');
     console.log('```');
-    console.log(`sc.exe stop "${this.serviceName}"`);
-    console.log(`sc.exe delete "${this.serviceName}"`);
+    console.log(`sc.exe . stop "${this.serviceName}"`);
+    console.log(`sc.exe . delete "${this.serviceName}"`);
     console.log('```\n');
 
     console.log('📊 Service Information:');
@@ -89,13 +89,13 @@ class ManualServiceInstaller {
 
     console.log('\n💡 Alternative single command (PowerShell):');
     console.log('```');
-    const singleCommand = `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto; sc.exe description "${this.serviceName}" "${this.serviceDescription}"; sc.exe start "${this.serviceName}"`;
+    const singleCommand = `sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto; sc.exe . description "${this.serviceName}" "${this.serviceDescription}"; sc.exe . start "${this.serviceName}"`;
     console.log(singleCommand);
     console.log('```\n');
 
     console.log('💡 For Command Prompt (cmd):');
     console.log('```');
-    const cmdCommand = `sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto && sc description "${this.serviceName}" "${this.serviceDescription}" && sc start "${this.serviceName}"`;
+    const cmdCommand = `sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto && sc.exe . description "${this.serviceName}" "${this.serviceDescription}" && sc.exe . start "${this.serviceName}"`;
     console.log(cmdCommand);
     console.log('```\n');
 

--- a/scripts/windows-service/install-service-simple.js
+++ b/scripts/windows-service/install-service-simple.js
@@ -41,7 +41,7 @@ class SimpleServiceInstaller {
     console.log('🔍 Checking for existing service...');
 
     try {
-      const result = execSync(`sc.exe query "${this.serviceName}"`, {
+      const result = execSync(`sc.exe . query "${this.serviceName}"`, {
         encoding: 'utf8',
       });
 
@@ -50,7 +50,7 @@ class SimpleServiceInstaller {
 
         // Stop service if running
         try {
-          execSync(`sc.exe stop "${this.serviceName}"`, { stdio: 'pipe' });
+          execSync(`sc.exe . stop "${this.serviceName}"`, { stdio: 'pipe' });
           console.log('🛑 Service stopped.');
           await new Promise((resolve) => setTimeout(resolve, 3000));
         } catch (err) {
@@ -58,7 +58,7 @@ class SimpleServiceInstaller {
         }
 
         // Delete service
-        execSync(`sc.exe delete "${this.serviceName}"`, { stdio: 'pipe' });
+        execSync(`sc.exe . delete "${this.serviceName}"`, { stdio: 'pipe' });
         console.log('🗑️  Existing service removed.');
 
         // Wait for cleanup
@@ -81,8 +81,8 @@ class SimpleServiceInstaller {
       console.log(`   Script: ${this.scriptPath}`);
 
       // Use sc.exe to avoid PowerShell alias conflicts
-      // Format: sc.exe create "ServiceName" binPath= "\"node.exe\" \"script.js\"" DisplayName= "Display Name" start= auto
-      const createCommand = `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`;
+      // Format: sc.exe <server> create "ServiceName" binPath= "\"node.exe\" \"script.js\"" DisplayName= "Display Name" start= auto
+      const createCommand = `sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`;
 
       console.log(`🔧 Running: ${createCommand}`);
 
@@ -93,7 +93,7 @@ class SimpleServiceInstaller {
 
       // Try alternative method with different quoting
       try {
-        const altCommand = `sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`;
+        const altCommand = `sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`;
         console.log(`🔧 Trying alternative: ${altCommand}`);
         execSync(altCommand, { stdio: 'inherit' });
         console.log('✅ Service created successfully with alternative method!');
@@ -103,10 +103,10 @@ Primary error: ${err.message}
 Alternative error: ${altErr.message}
 
 Manual command to try (PowerShell):
-sc.exe create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto
+sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto
 
 Manual command to try (Command Prompt):
-sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`);
+sc.exe . create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.scriptPath}\\"" DisplayName= "${this.serviceName}" start= auto`);
       }
     }
   }
@@ -116,7 +116,7 @@ sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.script
 
     try {
       // Set failure actions
-      const failureCommand = `sc.exe failure "${this.serviceName}" reset=3600 actions=restart/60000/restart/120000/restart/300000`;
+      const failureCommand = `sc.exe . failure "${this.serviceName}" reset=3600 actions=restart/60000/restart/120000/restart/300000`;
       execSync(failureCommand, { stdio: 'pipe' });
       console.log('✅ Service recovery options configured.');
     } catch (err) {
@@ -134,13 +134,13 @@ sc create "${this.serviceName}" binPath= "\\"${this.nodeExe}\\" \\"${this.script
     console.log('🚀 Starting service...');
 
     try {
-      execSync(`sc.exe start "${this.serviceName}"`, { stdio: 'pipe' });
+      execSync(`sc.exe . start "${this.serviceName}"`, { stdio: 'pipe' });
       console.log('✅ Service started successfully!');
 
       // Wait a moment and verify
       await new Promise((resolve) => setTimeout(resolve, 3000));
 
-      const result = execSync(`sc.exe query "${this.serviceName}"`, {
+      const result = execSync(`sc.exe . query "${this.serviceName}"`, {
         encoding: 'utf8',
       });
       if (result.includes('RUNNING')) {


### PR DESCRIPTION
…e control

- Fixed all sc.exe commands to include server parameter (. for local machine)
- Updated simple installer, manual installer, debug utility, and package.json
- Commands now follow proper format: sc.exe <server> <command> [options]
- Ensures proper Windows service control syntax compliance
- Fixes service creation, query, start, stop, delete, and failure commands

🤖 Generated with [Claude Code](https://claude.ai/code)