### PR TITLE
Fix service name mismatch - update to electricitytokenstrackerexe.exe

### DIFF
--- a/logs/service-wrapper-2025-07-03.log
+++ b/logs/service-wrapper-2025-07-03.log
@@ -1,0 +1,1 @@
+Test log entry for 2025-07-03

--- a/logs/service-wrapper-2025-07-08.log
+++ b/logs/service-wrapper-2025-07-08.log
@@ -1,0 +1,1 @@
+Test log entry for 2025-07-08

--- a/logs/service-wrapper-2025-07-13.log
+++ b/logs/service-wrapper-2025-07-13.log
@@ -1,0 +1,4 @@
+Test log entry for 2025-07-13
+[2025-07-13T23:04:46.698Z] [INFO] Test log message
+[2025-07-13T23:04:46.698Z] [WARN] Test warning message
+[2025-07-13T23:04:46.698Z] [ERROR] Test error message

--- a/scripts/windows-service/config.js
+++ b/scripts/windows-service/config.js
@@ -39,7 +39,7 @@ loadEnvironmentVariables();
 // Service configuration
 const SERVICE_CONFIG = {
   // Service identification
-  name: 'electricitytokenstracker.exe',
+  name: 'electricitytokenstrackerexe.exe',
   description:
     'Electricity Tokens Tracker - A web application for tracking electricity token purchases and usage',
 

--- a/scripts/windows-service/diagnose-hybrid.js
+++ b/scripts/windows-service/diagnose-hybrid.js
@@ -195,7 +195,7 @@ async function diagnoseService() {
     console.log(`\n⚙️  Service Configuration:`);
     try {
       const { stdout } = await execAsync(
-        `${config.commands.SC_COMMAND} qc "electricitytokenstracker.exe"`
+        `${config.commands.SC_COMMAND} qc "electricitytokenstrackerexe.exe"`
       );
       const lines = stdout.split('\n');
 

--- a/scripts/windows-service/find-service.js
+++ b/scripts/windows-service/find-service.js
@@ -119,6 +119,7 @@ class ServiceFinder {
     this.log('');
 
     const possibleNames = [
+      'electricitytokenstrackerexe.exe',
       'electricitytokenstracker.exe',
       'electricitytokenstracker',
       'ElectricityTokensTracker',

--- a/scripts/windows-service/fix-broken-service.js
+++ b/scripts/windows-service/fix-broken-service.js
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 
 class ServiceFixer {
   constructor() {
-    this.serviceName = 'electricitytokenstracker.exe';
+    this.serviceName = 'electricitytokenstrackerexe.exe';
   }
 
   async log(message, level = 'INFO') {

--- a/scripts/windows-service/force-install-hybrid.js
+++ b/scripts/windows-service/force-install-hybrid.js
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 
 class ForceInstallManager {
   constructor() {
-    this.serviceName = 'electricitytokenstracker.exe';
+    this.serviceName = 'electricitytokenstrackerexe.exe';
     this.daemonPath = path.join(__dirname, 'daemon');
   }
 

--- a/scripts/windows-service/hybrid-service-manager.js
+++ b/scripts/windows-service/hybrid-service-manager.js
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 
 class HybridServiceManager {
   constructor() {
-    this.serviceName = 'electricitytokenstracker.exe';
+    this.serviceName = 'electricitytokenstrackerexe.exe';
     this.appRoot = path.resolve(__dirname, '../..');
     this.logFile = path.join(this.appRoot, 'logs', 'hybrid-service.log');
     this.pidFile = path.join(this.appRoot, 'logs', 'service.pid');


### PR DESCRIPTION
Service Name Corrections:
- Update config.js service name to match actual registered service
- Fix force-install-hybrid.js service name reference
- Update fix-broken-service.js to use correct service name
- Correct diagnose-hybrid.js service query command
- Update hybrid-service-manager.js service name
- Add correct service name to find-service.js test list

Root Cause:
- node-windows created service as "electricitytokenstrackerexe.exe"
- Scripts were looking for "electricitytokenstracker.exe" (missing "exe")
- Service finder discovered the actual registered name
- Daemon files exist but name mismatch prevented service commands

Expected Result:
- npm run service:diagnose should now work
- npm run service:start should successfully start the service
- Service logging with daily rotation should function properly

🤖 Generated with [Claude Code](https://claude.ai/code)